### PR TITLE
Using UUID to generate unique ID

### DIFF
--- a/lib/presentation/screens/ManualBillScreen.dart
+++ b/lib/presentation/screens/ManualBillScreen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' hide Split;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:uuid/uuid.dart';
 import '../../state/providers/split_providers.dart';
 import '../../domain/models/split.dart';
 import '../../domain/models/item.dart';
@@ -68,7 +69,7 @@ class _ManualBillScreenState extends ConsumerState<ManualBillScreen> {
       final amount = double.parse(_amountController.text.trim());
 
       final billItem = Item(
-        id: '${DateTime.now().millisecondsSinceEpoch}_item',
+        id: const Uuid().v4(),
         name: _titleController.text.trim(),
         price: amount,
         quantity: 1,
@@ -76,7 +77,7 @@ class _ManualBillScreenState extends ConsumerState<ManualBillScreen> {
       );
 
       final newSplit = Split(
-        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        id: const Uuid().v4(),
         name: _titleController.text.trim(),
         createdAt: _selectedDate,
         items: [billItem],

--- a/lib/state/providers/saved_people_providers.dart
+++ b/lib/state/providers/saved_people_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
 import '../../domain/models/saved_person.dart';
 import '../../data/local/hive_service.dart';
 import '../../core/utils/avatar_colors.dart';
@@ -51,7 +52,7 @@ class SavedPeopleNotifier extends StateNotifier<List<SavedPerson>> {
       final avatarColor =
           customColor ?? AvatarColors.getColorForName(trimmedName);
       final person = SavedPerson(
-        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        id: const Uuid().v4(),
         name: trimmedName,
         createdAt: DateTime.now(),
         useCount: 1,

--- a/lib/state/providers/split_providers.dart
+++ b/lib/state/providers/split_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
 import '../../domain/models/split.dart';
 import '../../domain/models/participant.dart';
 import '../../domain/models/item.dart';
@@ -78,7 +79,7 @@ class CurrentSplitNotifier extends StateNotifier<Split?> {
   /// Starts a new split.
   void startNewSplit({String? name}) {
     state = Split(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      id: const Uuid().v4(),
       name: name,
       createdAt: DateTime.now(),
     );
@@ -106,7 +107,7 @@ class CurrentSplitNotifier extends StateNotifier<Split?> {
     if (state == null || name.trim().isEmpty) return;
 
     final participant = Participant(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      id: const Uuid().v4(),
       name: name.trim(),
     );
 
@@ -141,7 +142,7 @@ class CurrentSplitNotifier extends StateNotifier<Split?> {
     }
 
     final item = Item(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      id: const Uuid().v4(),
       name: name.trim(),
       price: price,
       quantity: quantity,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   permission_handler: ^11.3.0
   qr: ^3.0.2
   qr_flutter: ^4.1.0
+  uuid: ^4.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR addresses Issue by replacing unsafe `DateTime.now().millisecondsSinceEpoch` ID generation with cryptographically unique UUIDs. This prevents ID collisions when multiple items are created simultaneously or if the system clock drifts.

## Summary by Sourcery

Replace time-based ID generation with UUIDs for splits, items, and saved people to ensure globally unique identifiers.

New Features:
- Introduce UUID-based identifiers for newly created splits, items, and saved people.

Enhancements:
- Add the uuid package dependency and integrate it into state notifiers and manual bill creation instead of timestamp-based IDs.